### PR TITLE
Enforce correct ABI in callback

### DIFF
--- a/libusb/io.c
+++ b/libusb/io.c
@@ -1719,7 +1719,10 @@ int usbi_handle_transfer_completion(struct usbi_transfer *itransfer,
 		 (void *) transfer, transfer->callback);
 	if (transfer->callback) {
 		libusb_lock_event_waiters (ctx);
-		transfer->callback(transfer);
+
+		typedef void sysv_callback_t(struct libusb_transfer*) __attribute__((sysv_abi));
+		((sysv_callback_t*)transfer->callback)(transfer);
+		
 		libusb_unlock_event_waiters(ctx);
 	}
 	/* transfer might have been freed by the above call, do not use from


### PR DESCRIPTION
Ensures that transfer callbacks are called by the host with the struct in the EDI/RDI register.

Allows LEGO Dimensions to go in-game.